### PR TITLE
Fully quote table name in copy_from

### DIFF
--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -54,7 +54,11 @@ def copy_from(source, dest, engine, **flags):
     conn = engine.raw_connection()
     cursor = conn.cursor()
     formatted_flags = '({})'.format(format_flags(flags)) if flags else ''
-    copy = 'COPY "{}"."{}" FROM STDIN {}'.format(tbl.schema, tbl.name, formatted_flags)
+    copy = 'COPY "{}"."{}" FROM STDIN {}'.format(
+        tbl.schema or 'public',
+        tbl.name,
+        formatted_flags
+    )
     cursor.copy_expert(copy, source)
     conn.commit()
     conn.close()

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Mapper, class_mapper
 from sqlalchemy.sql.operators import ColumnOperators
 from sqlalchemy.dialects import postgresql
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 def copy_to(source, dest, engine, **flags):
     """Export a query or select to a file. For flags, see the PostgreSQL

--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -50,11 +50,11 @@ def copy_from(source, dest, engine, **flags):
     :param dest: SQLAlchemy model or table
     :param engine: SQLAlchemy engine
     """
-    name = dest.__table__.fullname if is_model(dest) else dest.fullname
+    tbl = dest.__table__ if is_model(dest) else dest
     conn = engine.raw_connection()
     cursor = conn.cursor()
     formatted_flags = '({})'.format(format_flags(flags)) if flags else ''
-    copy = 'COPY {} FROM STDOUT {}'.format(name, formatted_flags)
+    copy = 'COPY "{}"."{}" FROM STDIN {}'.format(tbl.schema, tbl.name, formatted_flags)
     cursor.copy_expert(copy, source)
     conn.commit()
     conn.close()

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ def read(fname):
         content = fp.read()
     return content
 
+
 setup(
     name='sqlalchemy-postgres-copy',
     version=find_version('postgres_copy/__init__.py'),


### PR DESCRIPTION
Allows `copy_from` to tables with non-standard names (capitals, hyphens, etc).