### PR TITLE
Remove direct psycopg2 dependency and let user decide which to use

### DIFF
--- a/postgres_copy/__init__.py
+++ b/postgres_copy/__init__.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Mapper, class_mapper
 from sqlalchemy.sql.operators import ColumnOperators
 from sqlalchemy.dialects import postgresql
 
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 
 def copy_to(source, dest, engine_or_conn, **flags):
     """Export a query or select to a file. For flags, see the PostgreSQL

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,13 @@ from setuptools import find_packages
 
 REQUIRES = [
     'six',
-    'psycopg2',
+    # We recommend you install the version of the psycopg2 library
+    # that is right for you (if you don't know, 'psycopg2-binary' will
+    # probably work fine for you).
+    #
+    # https://github.com/psycopg/psycopg2/issues/674
+    #
+    # 'psycopg2',
     'sqlalchemy',
 ]
 


### PR DESCRIPTION
The psycopg2 dependency has gotten complicated due to a compatibility issue resulting in segfaults when using the binary-packaged version in some configurations.  They removed the pre-compiled version from the default psycopg2 package, which had the side effect of making more difficult for the average end-user to install without having development libraries and a compiler installed.

There's a full explanation here: https://github.com/psycopg/psycopg2/issues/674

Other dependent packages seem to be removing the transitive dependency and let the users decide which to use  - e.g., sqlalchemy-redshift here: https://github.com/fizyk/sqlalchemy-redshift/commit/1781ff8d9dd8642c39ab8aefed61e9b08058e6e1

I have a package here that I'd like to use sqlalchemy-postgres-copy in (https://github.com/bluelabsio/records-mover), and I'd prefer not to vendor it in or add a psycopg2 dependency because of this, so I thought I'd send a PR your way.  Let me know if it sounds right to you.

Fixes #12 but not in the same way proposed.